### PR TITLE
Fix popup positioning for non-zero y screen configurations

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,8 +99,8 @@ const changePosition = () => {
   const windowBounds = window.getBounds();
   const displayWorkArea = screen.getDisplayNearestPoint({
     x: trayBounds.x,
-    y: trayBounds.y,
-  }).workAreaSize;
+    y: trayBounds.y
+  }).workArea
   const taskBarPosition = Positioner.getTaskbarPosition(trayBounds);
 
   if (taskBarPosition == "top" || taskBarPosition == "bottom") {
@@ -119,16 +119,23 @@ const changePosition = () => {
         trayBounds,
         alignment
       );
-      window.setPosition(displayWorkArea.width - windowBounds.width, y, false);
+
+      window.setPosition(
+        displayWorkArea.width - windowBounds.width + displayWorkArea.x,
+        y + (taskBarPosition == 'bottom' && displayWorkArea.y),
+        false
+      )
     }
   } else {
     const alignment = { x: taskBarPosition, y: "center" };
     if (
       trayBounds.y + (trayBounds.height + windowBounds.height) / 2 <
       displayWorkArea.height
-    )
-      Positioner.position(window, trayBounds, alignment);
-    else {
+    ) {
+      const {x, y} = Positioner.calculate(window.getBounds(), trayBounds, alignment)
+      window.setPosition(x + (taskBarPosition == 'right' && displayWorkArea.x), y)
+
+    } else {
       const { x } = Positioner.calculate(
         window.getBounds(),
         trayBounds,
@@ -136,7 +143,7 @@ const changePosition = () => {
       );
       window.setPosition(
         x,
-        displayWorkArea.height - windowBounds.height,
+        displayWorkArea.y + displayWorkArea.height - windowBounds.height,
         false
       );
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1159091/140609254-5da7e069-c4e8-4c2c-9eef-0b0e93782083.png)

My monitor setup is as above, with the taskbar on the top 
Most notably, display 2 has a top-left origin of `(1920, -486)`

The current implementation (likely within `electron-traywindow-positioner`???) for taskbar positioning fails to correctly address the 486px vertical offset.

This PR aims to apply these screen offsets to fix the display positioning

---

Platform: Windows 10  
homeassistant-desktop version: 1.4.3